### PR TITLE
Fix tests and core ML service

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,61 +1,21 @@
 module.exports = {
   preset: 'jest-expo',
   testEnvironment: 'jsdom',
-  
-  // Test file patterns
-  testMatch: [
-    '**/__tests__/**/*.(ts|tsx|js)',
-    '**/*.(test|spec).(ts|tsx|js)'
-  ],
-  
-  // Setup files
+  setupFiles: ['<rootDir>/jest.pre.js', require.resolve('jest-expo/src/preset/setup.js')],
+  testMatch: ['**/__tests__/**/*.(ts|tsx|js)', '**/*.(test|spec).(ts|tsx|js)'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
-  
-  // Module file extensions
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
-  
-  // Module name mapping
   moduleNameMapper: {
     '^@/(.*)': '<rootDir>/src/$1',
     '^~/(.*)': '<rootDir>/$1'
   },
-  
-  // Ignore patterns
-  testPathIgnorePatterns: [
-    '/node_modules/',
-    '/ios/',
-    '/android/',
-    '/.expo/'
-  ],
-  
-  // Transform ignore patterns
+  testPathIgnorePatterns: ['/node_modules/', '/ios/', '/android/', '/.expo/'],
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)'
+    'node_modules/(?!(jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)'
   ],
-  
-  // Transform configuration
   transform: {
-    '^.+\.(js|jsx|ts|tsx)
-  
-  // Coverage settings
-  collectCoverageFrom: [
-    'src/**/*.{ts,tsx}',
-    '!src/**/*.d.ts',
-    '!src/**/__tests__/**'
-  ],
-  
-  // Timeout
-  testTimeout: 10000
-};: 'babel-jest',
+    '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest'
   },
-  
-  // Coverage settings
-  collectCoverageFrom: [
-    'src/**/*.{ts,tsx}',
-    '!src/**/*.d.ts',
-    '!src/**/__tests__/**'
-  ],
-  
-  // Timeout
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts', '!src/**/__tests__/**'],
   testTimeout: 10000
 };

--- a/jest.pre.js
+++ b/jest.pre.js
@@ -1,0 +1,9 @@
+const NativeModules = require('react-native/Libraries/BatchedBridge/NativeModules');
+
+// Ensure UIManager and NativeUnimoduleProxy exist before jest-expo setup runs
+if (!NativeModules.UIManager) {
+  NativeModules.UIManager = {};
+}
+if (!NativeModules.NativeUnimoduleProxy) {
+  NativeModules.NativeUnimoduleProxy = { viewManagersMetadata: {} };
+}

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -87,6 +87,8 @@ jest.mock('react-native', () => {
         generateText: jest.fn(),
       }
     },
+    UIManager: {},
+    NativeUnimoduleProxy: { viewManagersMetadata: {} },
     NativeEventEmitter: jest.fn(() => ({
       addListener: jest.fn(),
       removeListener: jest.fn(),

--- a/patches/jest-expo+52.0.6.patch
+++ b/patches/jest-expo+52.0.6.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/jest-expo/src/preset/setup.js b/node_modules/jest-expo/src/preset/setup.js
+index db69c0f..12881e2 100644
+--- a/node_modules/jest-expo/src/preset/setup.js
++++ b/node_modules/jest-expo/src/preset/setup.js
+@@ -117,16 +117,26 @@ for (const moduleName of Object.keys(expoModules)) {
+   });
+ }
+ 
+-Object.keys(mockNativeModules.NativeUnimoduleProxy.viewManagersMetadata).forEach(
+-  (viewManagerName) => {
+-    Object.defineProperty(mockNativeModules.UIManager, `ViewManagerAdapter_${viewManagerName}`, {
+-      get: () => ({
+-        NativeProps: {},
+-        directEventTypes: [],
+-      }),
+-    });
+-  }
+-);
++if (
++  mockNativeModules.UIManager &&
++  mockNativeModules.NativeUnimoduleProxy &&
++  mockNativeModules.NativeUnimoduleProxy.viewManagersMetadata
++) {
++  Object.keys(mockNativeModules.NativeUnimoduleProxy.viewManagersMetadata).forEach(
++    (viewManagerName) => {
++      Object.defineProperty(
++        mockNativeModules.UIManager,
++        `ViewManagerAdapter_${viewManagerName}`,
++        {
++          get: () => ({
++            NativeProps: {},
++            directEventTypes: [],
++          }),
++        }
++      );
++    }
++  );
++}
+ 
+ try {
+   jest.mock('expo-file-system', () => ({


### PR DESCRIPTION
## Summary
- clean up jest config and add pre-setup file
- fix mocked NativeModules for jest
- update core ML service initialization and fallback logic
- patch jest-expo to avoid errors when UIManager is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687782598a3c83339f11fc93c6007fb1

## Summary by Sourcery

Fix test suite by cleaning up Jest config and mocking unsupported NativeModules, and improve CoreMLService with model refreshing and fallback handling for download and generation failures

Bug Fixes:
- Resolve Jest errors by patching jest-expo and mocking missing UIManager and NativeUnimoduleProxy modules

Enhancements:
- Streamline Jest configuration with a pre-setup file and consolidated settings

Tests:
- Add jest.pre.js to initialize NativeModules before Jest setup and extend jest.setup.js mocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for model downloads and text generation, providing fallback responses if native services fail.
  * Enhanced robustness during testing by ensuring required native module mocks are present, preventing potential errors.

* **Chores**
  * Cleaned up and streamlined test configuration files for better readability and maintainability.
  * Updated test setup scripts and patches to ensure compatibility and prevent runtime errors during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->